### PR TITLE
Ignore WPCS discouraged functions in tests

### DIFF
--- a/tests/test-img-shortcode.php
+++ b/tests/test-img-shortcode.php
@@ -82,8 +82,10 @@ EOL;
 		$contents = rand_str();
 
 		if ( $image ) {
+			// @codingStandardsIgnoreStart
 			$filename = basename( $image );
 			$contents = file_get_contents( $image );
+			// @codingStandardsIgnoreEnd
 		}
 
 		$upload = wp_upload_bits( $filename, null, $contents );


### PR DESCRIPTION
Ignore WPCS VIP sniffs so that test files can pass linting.