### PR TITLE
Fix "size" and "align" attributes on media_send_to_editor function

### DIFF
--- a/image-shortcake.php
+++ b/image-shortcake.php
@@ -62,7 +62,7 @@ class Image_Shortcake {
 	 *
 	 */
 	private function setup_filters() {
-		add_filter( 'media_send_to_editor', 'Img_Shortcode::filter_media_send_to_editor', 10, 3 );
+		add_filter( 'media_send_to_editor', 'Img_Shortcode::filter_media_send_to_editor', 15, 3 );
 	}
 
 

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -304,9 +304,12 @@ class Img_Shortcode {
 			$shortcode_attrs['attachment'] = $attachment_id;
 		}
 
+		if ( ! empty( $attachment['align'] ) ) {
+			$shortcode_attrs['align'] = 'align' . $attachment['align'];
+		}
+
 		$allowed_attrs = array(
-			'size' => 'size',
-			'align' => 'align',
+			'image-size' => 'size',
 			'image_alt' => 'alt',
 			'post_excerpt' => 'caption',
 		);

--- a/tests/test-img-shortcode.php
+++ b/tests/test-img-shortcode.php
@@ -69,6 +69,51 @@ EOL;
 
 
 	/**
+	 * Test that an image inserted from the editor is transformed into a
+	 * shortcode correctly.
+	 */
+	function test_media_send_to_editor() {
+
+		$attachment_data = array(
+			'post_title'     => 'Post',
+			'post_content'   => 'Post Content',
+			'post_date'      => '2014-10-01 17:28:00',
+			'post_status'    => 'publish',
+			'post_type'      => 'attachment',
+		);
+
+		$attachment_id = $this->insert_attachment( null,
+			dirname( __FILE__ ) . '/data/fusion_image_placeholder_16x9_h2000.png',
+			$attachment_data
+		);
+
+		/**
+		 * Fields in the media editor form
+		 */
+		$attachment_data = array_merge(
+			$attachment_data,
+			array(
+				'id'           => $attachment_id,
+				'post_content' => 'This is the description',
+				'post_excerpt' => 'This is the caption',
+				'align'        => 'right',
+				'image-size'   => 'large',
+				'image_alt'    => 'This is the alt',
+				'url'          => get_permalink( $attachment_id ),
+			)
+		);
+
+		$shortcode = apply_filters( 'media_send_to_editor', '', $attachment_id, $attachment_data );
+
+		$this->assertContains( '[img ', $shortcode );
+		$this->assertContains( 'size="large"', $shortcode );
+		$this->assertContains( 'align="alignright"', $shortcode );
+		$this->assertContains( 'caption="This is the caption"', $shortcode );
+
+	}
+
+
+	/**
 	 * Helper function: insert an attachment to test properties of.
 	 *
 	 * @param int $parent_post_id


### PR DESCRIPTION
Fixes a bug where these values set in the Media Library didn't get picked up by the shortcode, due to incorrect mapping between the attachment post values and shortcode attributes. 

Includes tests. 