### PR TITLE
Add internationalization for all strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-=== Image-shortcake ===
-Contributors: fusionengineering
-Donate link: http://example.com/
-Tags: comments, spam
-Requires at least: 3.0.1
-Tested up to: 3.4
-Stable tag: 4.3
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+# Image-shortcake #
+**Contributors:** fusionengineering  
+**Donate link:** http://example.com/  
+**Tags:** comments, spam  
+**Requires at least:** 3.0.1  
+**Tested up to:** 3.4  
+**Stable tag:** 4.3  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
 Image Shortcake adds a shortcode for images, so that themes can template and
 filter images displayed in posts. It is designed to work with the UI provided
 by the [Shortcake (Shortcode UI)](https://github.com/fusioneng/Shortcake)
 plugin,
 
-== Description ==
+## Description ##
 
 When images are inserted into posts from the media library or media uploader,
 only the html of the `<img>` tag and the link around it (if any) are preserved.
@@ -28,8 +28,8 @@ easier for modify the way images are marked up in themes.
 
 For best results, use with [Shortcake (Shortcode UI)](https://github.com/fusioneng/Shortcake) plugin.
 
-== Changelog ==
+## Changelog ##
 
-= 0.1 =
+### 0.1 ###
 Initial release (May 1, 2015)
 

--- a/image-shortcake.php
+++ b/image-shortcake.php
@@ -3,7 +3,7 @@
 Plugin Name: Image-shortcake
 Version: 0.1-alpha
 Description: Provides a shortcode for image elements. Use with the Shortcake plugin for a preview of images
-Author: goldenapples
+Author: fusionengineering, goldenapples
 Author URI: https://github.com/fusioneng
 Plugin URI: https://github.com/fusioneng/image-shortcake
 Text Domain: image-shortcake

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -19,68 +19,83 @@ class Img_Shortcode {
 
 		$shortcode_ui_args = array(
 
-				'label' => esc_attr__( 'Image' ),
+				'label' => esc_attr__( 'Image', 'image-shortcake' ),
 
 				'listItemImage' => 'dashicons-format-image',
 
 				'attrs' => array(
 
 					array(
-						'label' => esc_attr__( 'Choose Attachment' ),
+						'label' => esc_attr__( 'Choose Attachment', 'image-shortcake' ),
 						'attr'  => 'attachment',
 						'type'  => 'attachment',
 						'libraryType' => array( 'image' ),
-						'addButton'   => esc_attr__( 'Select Image' ),
-						'frameTitle'  => esc_attr__( 'Select Image' ),
+						'addButton'   => esc_attr__( 'Select Image', 'image-shortcake' ),
+						'frameTitle'  => esc_attr__( 'Select Image', 'image-shortcake' ),
 					),
 
 					array(
-						'label'       => esc_attr__( 'Image size' ),
+						'label'       => esc_attr__( 'Image size', 'image-shortcake' ),
 						'attr'        => 'size',
 						'type'        => 'select',
 						'options' => array(
-							'thumb'  => esc_attr( sprintf( __( 'Thumbnail (%s px)' ), get_option('thumbnail_size_w') ) ),
-							'medium' => esc_attr( sprintf( __( 'Medium (%s px)' ), get_option('medium_size_w') ) ),
-							'large'  => esc_attr( sprintf( __( 'Large (%s px)' ), get_option('large_size_w') ) ),
-							'full'   => esc_attr__( 'Full size' )
+							'thumb'  => esc_attr(
+								sprintf(
+									__( 'Thumbnail (%s px)', 'image-shortcake' ),
+									get_option('thumbnail_size_w')
+								)
+							),
+							'medium' => esc_attr(
+								sprintf(
+									__( 'Medium (%s px)', 'image-shortcake' ),
+									get_option('medium_size_w')
+								)
+							),
+							'large'  => esc_attr(
+								sprintf(
+									__( 'Large (%s px)', 'image-shortcake' ),
+									get_option('large_size_w')
+								)
+							),
+							'full'   => esc_attr__( 'Full size', 'image-shortcake' )
 						),
 					),
 
 					array(
-						'label' => esc_attr__( 'Alt' ),
+						'label' => esc_attr__( 'Alt', 'image-shortcake' ),
 						'attr'  => 'alt',
 						'type'  => 'text',
-						'placeholder' => esc_attr__( 'Alt text for the image' ),
+						'placeholder' => esc_attr__( 'Alt text for the image', 'image-shortcake' ),
 					),
 
 					array(
-						'label'       => esc_attr__( 'Caption' ),
+						'label'       => esc_attr__( 'Caption', 'image-shortcake' ),
 						'attr'        => 'caption',
 						'type'        => 'text',
-						'placeholder' => esc_attr__( 'Caption for the image' ),
+						'placeholder' => esc_attr__( 'Caption for the image', 'image-shortcake' ),
 					),
 
 					array(
-						'label'       => esc_attr__( 'Alignment' ),
+						'label'       => esc_attr__( 'Alignment', 'image-shortcake' ),
 						'attr'        => 'align',
 						'type'        => 'select',
 						'options' => array(
-							'alignnone'   => esc_attr__( 'None (inline)' ),
-							'alignleft'   => esc_attr__( 'Float left' ),
-							'alignright'  => esc_attr__( 'Float right' ),
-							'aligncenter' => esc_attr__( 'Center' ),
+							'alignnone'   => esc_attr__( 'None (inline)', 'image-shortcake' ),
+							'alignleft'   => esc_attr__( 'Float left',    'image-shortcake' ),
+							'alignright'  => esc_attr__( 'Float right',   'image-shortcake' ),
+							'aligncenter' => esc_attr__( 'Center',        'image-shortcake' ),
 						),
 					),
 
 					array(
-						'label'       => esc_attr__( 'Link to' ),
+						'label'       => esc_attr__( 'Link to', 'image-shortcake' ),
 						'attr'        => 'linkto',
 						'type'        => 'select',
 						'options' => array(
-							'none'       => esc_attr__( 'None (no link)' ),
-							'attachment' => esc_attr__( 'Link to attachment file' ),
-							'file'       => esc_attr__( 'Link to file' ),
-							'custom'     => esc_attr__( 'Custom link' ),
+							'none'       => esc_attr__( 'None (no link)',          'image-shortcake' ),
+							'attachment' => esc_attr__( 'Link to attachment file', 'image-shortcake' ),
+							'file'       => esc_attr__( 'Link to file',            'image-shortcake' ),
+							'custom'     => esc_attr__( 'Custom link',             'image-shortcake' ),
 						),
 					),
 

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -39,7 +39,7 @@ class Img_Shortcode {
 						'attr'        => 'size',
 						'type'        => 'select',
 						'options' => array(
-							'thumb'  => esc_attr(
+							'thumbnail' => esc_attr(
 								sprintf(
 									__( 'Thumbnail (%s px)', 'image-shortcake' ),
 									get_option('thumbnail_size_w')
@@ -51,13 +51,13 @@ class Img_Shortcode {
 									get_option('medium_size_w')
 								)
 							),
-							'large'  => esc_attr(
+							'large' => esc_attr(
 								sprintf(
 									__( 'Large (%s px)', 'image-shortcake' ),
 									get_option('large_size_w')
 								)
 							),
-							'full'   => esc_attr__( 'Full size', 'image-shortcake' )
+							'full' => esc_attr__( 'Full size', 'image-shortcake' )
 						),
 					),
 

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -19,68 +19,68 @@ class Img_Shortcode {
 
 		$shortcode_ui_args = array(
 
-				'label' => 'Image',
+				'label' => esc_attr__( 'Image' ),
 
 				'listItemImage' => 'dashicons-format-image',
 
 				'attrs' => array(
 
 					array(
-						'label' => 'Choose Attachment',
+						'label' => esc_attr__( 'Choose Attachment' ),
 						'attr'  => 'attachment',
 						'type'  => 'attachment',
 						'libraryType' => array( 'image' ),
-						'addButton'   => 'Select Image',
-						'frameTitle'  => 'Select Image',
+						'addButton'   => esc_attr__( 'Select Image' ),
+						'frameTitle'  => esc_attr__( 'Select Image' ),
 					),
 
 					array(
-						'label'       => 'Image size',
+						'label'       => esc_attr__( 'Image size' ),
 						'attr'        => 'size',
 						'type'        => 'select',
 						'options' => array(
-							'thumbnail' => 'Thumbnail',
-							'small'     => 'Small',
-							'medium'    => 'Medium',
-							'large'     => 'Large',
+							'thumb'  => esc_attr( sprintf( __( 'Thumbnail (%s px)' ), get_option('thumbnail_size_w') ) ),
+							'medium' => esc_attr( sprintf( __( 'Medium (%s px)' ), get_option('medium_size_w') ) ),
+							'large'  => esc_attr( sprintf( __( 'Large (%s px)' ), get_option('large_size_w') ) ),
+							'full'   => esc_attr__( 'Full size' )
 						),
 					),
 
 					array(
-						'label' => 'Alt',
+						'label' => esc_attr__( 'Alt' ),
 						'attr'  => 'alt',
 						'type'  => 'text',
-						'placeholder' => 'Alt text for the image',
+						'placeholder' => esc_attr__( 'Alt text for the image' ),
 					),
 
 					array(
-						'label'       => 'Caption',
+						'label'       => esc_attr__( 'Caption' ),
 						'attr'        => 'caption',
 						'type'        => 'text',
-						'placeholder' => 'Caption for the image',
+						'placeholder' => esc_attr__( 'Caption for the image' ),
 					),
 
 					array(
-						'label'       => 'Alignment',
+						'label'       => esc_attr__( 'Alignment' ),
 						'attr'        => 'align',
 						'type'        => 'select',
 						'options' => array(
-							'alignleft'   => 'Float left',
-							'alignright'  => 'Float right',
-							'aligncenter' => 'Center',
-							'alignnone'   => 'None (inline)',
+							'alignnone'   => esc_attr__( 'None (inline)' ),
+							'alignleft'   => esc_attr__( 'Float left' ),
+							'alignright'  => esc_attr__( 'Float right' ),
+							'aligncenter' => esc_attr__( 'Center' ),
 						),
 					),
 
 					array(
-						'label'       => 'Link to',
+						'label'       => esc_attr__( 'Link to' ),
 						'attr'        => 'linkto',
 						'type'        => 'select',
 						'options' => array(
-							'none'       => 'None (no link)',
-							'attachment' => 'Link to attachment file',
-							'file'       => 'Link to file',
-							'custom'     => 'Custom link',
+							'none'       => esc_attr__( 'None (no link)' ),
+							'attachment' => esc_attr__( 'Link to attachment file' ),
+							'file'       => esc_attr__( 'Link to file' ),
+							'custom'     => esc_attr__( 'Custom link' ),
 						),
 					),
 

--- a/languages/image-shortcake.pot
+++ b/languages/image-shortcake.pot
@@ -1,10 +1,10 @@
-# Copyright (C) 2015 goldenapples
+# Copyright (C) 2015 fusionengineering, goldenapples
 # This file is distributed under the same license as the Image-shortcake package.
 msgid ""
 msgstr ""
 "Project-Id-Version: Image-shortcake 0.1-alpha\n"
 "Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/image-shortcake\n"
-"POT-Creation-Date: 2015-05-02 23:50:34+00:00\n"
+"POT-Creation-Date: 2015-05-04 14:42:41+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -30,91 +30,91 @@ msgid ""
 "shortcode."
 msgstr ""
 
-#: inc/class-img-shortcode.php:21 inc/class-img-shortcode.php:49
-msgid "Thumbnail (%s px)"
-msgstr ""
-
-#: inc/class-img-shortcode.php:22 inc/class-img-shortcode.php:50
-msgid "Medium (%s px)"
-msgstr ""
-
-#: inc/class-img-shortcode.php:23 inc/class-img-shortcode.php:51
-msgid "Large (%s px)"
-msgstr ""
-
-#: inc/class-img-shortcode.php:24 inc/class-img-shortcode.php:52
-msgid "Full size"
-msgstr ""
-
-#: inc/class-img-shortcode.php:29
+#: inc/class-img-shortcode.php:22
 msgid "Image"
 msgstr ""
 
-#: inc/class-img-shortcode.php:36
+#: inc/class-img-shortcode.php:29
 msgid "Choose Attachment"
 msgstr ""
 
-#: inc/class-img-shortcode.php:40 inc/class-img-shortcode.php:41
+#: inc/class-img-shortcode.php:33 inc/class-img-shortcode.php:34
 msgid "Select Image"
 msgstr ""
 
-#: inc/class-img-shortcode.php:45
+#: inc/class-img-shortcode.php:38
 msgid "Image size"
 msgstr ""
 
-#: inc/class-img-shortcode.php:57
-msgid "Alt"
+#: inc/class-img-shortcode.php:44
+msgid "Thumbnail (%s px)"
+msgstr ""
+
+#: inc/class-img-shortcode.php:50
+msgid "Medium (%s px)"
+msgstr ""
+
+#: inc/class-img-shortcode.php:56
+msgid "Large (%s px)"
 msgstr ""
 
 #: inc/class-img-shortcode.php:60
+msgid "Full size"
+msgstr ""
+
+#: inc/class-img-shortcode.php:65
+msgid "Alt"
+msgstr ""
+
+#: inc/class-img-shortcode.php:68
 msgid "Alt text for the image"
 msgstr ""
 
-#: inc/class-img-shortcode.php:64
+#: inc/class-img-shortcode.php:72
 msgid "Caption"
 msgstr ""
 
-#: inc/class-img-shortcode.php:67
+#: inc/class-img-shortcode.php:75
 msgid "Caption for the image"
 msgstr ""
 
-#: inc/class-img-shortcode.php:71
+#: inc/class-img-shortcode.php:79
 msgid "Alignment"
 msgstr ""
 
-#: inc/class-img-shortcode.php:75
+#: inc/class-img-shortcode.php:83
 msgid "None (inline)"
 msgstr ""
 
-#: inc/class-img-shortcode.php:76
+#: inc/class-img-shortcode.php:84
 msgid "Float left"
 msgstr ""
 
-#: inc/class-img-shortcode.php:77
+#: inc/class-img-shortcode.php:85
 msgid "Float right"
 msgstr ""
 
-#: inc/class-img-shortcode.php:78
+#: inc/class-img-shortcode.php:86
 msgid "Center"
 msgstr ""
 
-#: inc/class-img-shortcode.php:83
+#: inc/class-img-shortcode.php:91
 msgid "Link to"
 msgstr ""
 
-#: inc/class-img-shortcode.php:87
+#: inc/class-img-shortcode.php:95
 msgid "None (no link)"
 msgstr ""
 
-#: inc/class-img-shortcode.php:88
+#: inc/class-img-shortcode.php:96
 msgid "Link to attachment file"
 msgstr ""
 
-#: inc/class-img-shortcode.php:89
+#: inc/class-img-shortcode.php:97
 msgid "Link to file"
 msgstr ""
 
-#: inc/class-img-shortcode.php:90
+#: inc/class-img-shortcode.php:98
 msgid "Custom link"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgid ""
 msgstr ""
 
 #. Author of the plugin/theme
-msgid "goldenapples"
+msgid "fusionengineering, goldenapples"
 msgstr ""
 
 #. Author URI of the plugin/theme

--- a/languages/image-shortcake.pot
+++ b/languages/image-shortcake.pot
@@ -1,0 +1,141 @@
+# Copyright (C) 2015 goldenapples
+# This file is distributed under the same license as the Image-shortcake package.
+msgid ""
+msgstr ""
+"Project-Id-Version: Image-shortcake 0.1-alpha\n"
+"Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/image-shortcake\n"
+"POT-Creation-Date: 2015-05-02 23:50:34+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2015-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: grunt-wp-i18n 0.5.1\n"
+"X-Poedit-KeywordsList: "
+"__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_"
+"attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-Country: United States\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: ../\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-Bookmarks: \n"
+"X-Textdomain-Support: yes\n"
+
+#: image-shortcake.php:80
+msgid ""
+"Shortcode UI plugin is not active. No UI will be available for the image "
+"shortcode."
+msgstr ""
+
+#: inc/class-img-shortcode.php:21 inc/class-img-shortcode.php:49
+msgid "Thumbnail (%s px)"
+msgstr ""
+
+#: inc/class-img-shortcode.php:22 inc/class-img-shortcode.php:50
+msgid "Medium (%s px)"
+msgstr ""
+
+#: inc/class-img-shortcode.php:23 inc/class-img-shortcode.php:51
+msgid "Large (%s px)"
+msgstr ""
+
+#: inc/class-img-shortcode.php:24 inc/class-img-shortcode.php:52
+msgid "Full size"
+msgstr ""
+
+#: inc/class-img-shortcode.php:29
+msgid "Image"
+msgstr ""
+
+#: inc/class-img-shortcode.php:36
+msgid "Choose Attachment"
+msgstr ""
+
+#: inc/class-img-shortcode.php:40 inc/class-img-shortcode.php:41
+msgid "Select Image"
+msgstr ""
+
+#: inc/class-img-shortcode.php:45
+msgid "Image size"
+msgstr ""
+
+#: inc/class-img-shortcode.php:57
+msgid "Alt"
+msgstr ""
+
+#: inc/class-img-shortcode.php:60
+msgid "Alt text for the image"
+msgstr ""
+
+#: inc/class-img-shortcode.php:64
+msgid "Caption"
+msgstr ""
+
+#: inc/class-img-shortcode.php:67
+msgid "Caption for the image"
+msgstr ""
+
+#: inc/class-img-shortcode.php:71
+msgid "Alignment"
+msgstr ""
+
+#: inc/class-img-shortcode.php:75
+msgid "None (inline)"
+msgstr ""
+
+#: inc/class-img-shortcode.php:76
+msgid "Float left"
+msgstr ""
+
+#: inc/class-img-shortcode.php:77
+msgid "Float right"
+msgstr ""
+
+#: inc/class-img-shortcode.php:78
+msgid "Center"
+msgstr ""
+
+#: inc/class-img-shortcode.php:83
+msgid "Link to"
+msgstr ""
+
+#: inc/class-img-shortcode.php:87
+msgid "None (no link)"
+msgstr ""
+
+#: inc/class-img-shortcode.php:88
+msgid "Link to attachment file"
+msgstr ""
+
+#: inc/class-img-shortcode.php:89
+msgid "Link to file"
+msgstr ""
+
+#: inc/class-img-shortcode.php:90
+msgid "Custom link"
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Image-shortcake"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "https://github.com/fusioneng/image-shortcake"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"Provides a shortcode for image elements. Use with the Shortcake plugin for "
+"a preview of images"
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "goldenapples"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "https://github.com/fusioneng"
+msgstr ""


### PR DESCRIPTION
New pull request because #17 that I opened had additional commits in it.

Addresses #10, makes all strings translatable.  Also adds a basic readme file.