### PR TITLE
Ensure that caption shortcode has a width defined

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -291,9 +291,16 @@ class Img_Shortcode {
 				'align' => '',
 				'url' => '',
 				'size' => '',
+				'width' => '',
 				'alt' => '',
 			)
 		);
+
+		// Ensure the image has a width defined; caption shortcode will break otherwise.
+		if ( 0 === intval( $attributes['width'] ) ) {
+			$_attachment_src = wp_get_attachment_image_src( $_id, $attributes['size'] );
+			$attributes['width'] = $_attachment_src[1];
+		}
 
 		$html = img_caption_shortcode( $attributes, $img_tag );
 
@@ -327,6 +334,7 @@ class Img_Shortcode {
 			'image-size' => 'size',
 			'image_alt' => 'alt',
 			'post_excerpt' => 'caption',
+			'width' => 'width',
 		);
 
 		foreach ( $allowed_attrs as $attachment_attr => $shortcode_attr ) {


### PR DESCRIPTION
Themes without html5 caption support don't display anything for the caption if no width is defined for the caption input. This looks up the width from the original image if it's not set on the shortcode.