### PR TITLE
Prevent PHP notice when looking up image size

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -298,8 +298,9 @@ class Img_Shortcode {
 
 		// Ensure the image has a width defined; caption shortcode will break otherwise.
 		if ( 0 === intval( $attributes['width'] ) ) {
-			$_attachment_src = wp_get_attachment_image_src( $_id, $attributes['size'] );
-			$attributes['width'] = $_attachment_src[1];
+			if ( $_attachment_src = wp_get_attachment_image_src( $attributes['id'], $attributes['size'] ) ) {
+				$attributes['width'] = $_attachment_src[1];
+			}
 		}
 
 		$html = img_caption_shortcode( $attributes, $img_tag );


### PR DESCRIPTION
Make sure that the attachment ID refers to a valid attachment before
checking its width.