### PR TITLE
Include custom image sizes in shortcode UI

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -16,6 +16,30 @@ class Img_Shortcode {
 	 * filter.
 	 */
 	public static function get_shortcode_ui_args() {
+		global $_wp_additional_image_sizes;
+
+		$default_sizes = array(
+			'thumbnail' => __( 'Thumbnail', 'image-shortcake' ),
+			'medium'    => __( 'Medium',    'image-shortcake' ),
+			'large'     => __( 'Large',     'image-shortcake' ),
+			'full'      => __( 'Full size', 'image-shortcake' ),
+		);
+		$sizes_available = array();
+
+		foreach ( apply_filters( 'image_size_names_choose', $default_sizes ) as $key => $name ) {
+
+			$size = get_option( "${key}_size_w" );
+
+			if ( false === $size ) {
+				if ( array_key_exists( $key, $_wp_additional_image_sizes ) ) {
+					$size = $_wp_additional_image_sizes[ $key ]['width'];
+				}
+			}
+
+			$size_str = $size ? " (${size}px)" : '';
+
+			$sizes_available[$key] = esc_attr( "${name}${size_str}" );
+		}
 
 		$shortcode_ui_args = array(
 
@@ -38,33 +62,13 @@ class Img_Shortcode {
 						'label'       => esc_attr__( 'Image size', 'image-shortcake' ),
 						'attr'        => 'size',
 						'type'        => 'select',
-						'options' => array(
-							'thumbnail' => esc_attr(
-								sprintf(
-									__( 'Thumbnail (%s px)', 'image-shortcake' ),
-									get_option('thumbnail_size_w')
-								)
-							),
-							'medium' => esc_attr(
-								sprintf(
-									__( 'Medium (%s px)', 'image-shortcake' ),
-									get_option('medium_size_w')
-								)
-							),
-							'large' => esc_attr(
-								sprintf(
-									__( 'Large (%s px)', 'image-shortcake' ),
-									get_option('large_size_w')
-								)
-							),
-							'full' => esc_attr__( 'Full size', 'image-shortcake' )
-						),
+						'options'     => $sizes_available,
 					),
 
 					array(
-						'label' => esc_attr__( 'Alt', 'image-shortcake' ),
-						'attr'  => 'alt',
-						'type'  => 'text',
+						'label'       => esc_attr__( 'Alt', 'image-shortcake' ),
+						'attr'        => 'alt',
+						'type'        => 'text',
 						'placeholder' => esc_attr__( 'Alt text for the image', 'image-shortcake' ),
 					),
 

--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -19,10 +19,10 @@ class Img_Shortcode {
 		global $_wp_additional_image_sizes;
 
 		$default_sizes = array(
-			'thumbnail' => __( 'Thumbnail', 'image-shortcake' ),
-			'medium'    => __( 'Medium',    'image-shortcake' ),
-			'large'     => __( 'Large',     'image-shortcake' ),
-			'full'      => __( 'Full size', 'image-shortcake' ),
+			'thumbnail' => esc_html__( 'Thumbnail', 'image-shortcake' ),
+			'medium'    => esc_html__( 'Medium',    'image-shortcake' ),
+			'large'     => esc_html__( 'Large',     'image-shortcake' ),
+			'full'      => esc_html__( 'Full size', 'image-shortcake' ),
 		);
 		$sizes_available = array();
 
@@ -36,9 +36,9 @@ class Img_Shortcode {
 				}
 			}
 
-			$size_str = $size ? " (${size}px)" : '';
+			$size_str = $size ? " ({$size}px)" : '';
 
-			$sizes_available[$key] = esc_attr( "${name}${size_str}" );
+			$sizes_available[$key] = esc_attr( "{$name}{$size_str}" );
 		}
 
 		$shortcode_ui_args = array(


### PR DESCRIPTION
Runs the image sizes available through the `image_size_names_choose`
filter, so that custom image sizes added in themes can also be available
for selection through the UI here.

Addresses #24.