### PR TITLE
Set default values on all select fields

### DIFF
--- a/inc/class-img-shortcode.php
+++ b/inc/class-img-shortcode.php
@@ -38,6 +38,7 @@ class Img_Shortcode {
 						'label'       => esc_attr__( 'Image size', 'image-shortcake' ),
 						'attr'        => 'size',
 						'type'        => 'select',
+						'value'       => 'large',
 						'options' => array(
 							'thumbnail' => esc_attr(
 								sprintf(
@@ -79,6 +80,7 @@ class Img_Shortcode {
 						'label'       => esc_attr__( 'Alignment', 'image-shortcake' ),
 						'attr'        => 'align',
 						'type'        => 'select',
+						'value'       => 'aligncenter',
 						'options' => array(
 							'alignnone'   => esc_attr__( 'None (inline)', 'image-shortcake' ),
 							'alignleft'   => esc_attr__( 'Float left',    'image-shortcake' ),
@@ -91,6 +93,7 @@ class Img_Shortcode {
 						'label'       => esc_attr__( 'Link to', 'image-shortcake' ),
 						'attr'        => 'linkto',
 						'type'        => 'select',
+						'value'       => get_option( 'image_default_link_type' ),
 						'options' => array(
 							'none'       => esc_attr__( 'None (no link)',          'image-shortcake' ),
 							'attachment' => esc_attr__( 'Link to attachment file', 'image-shortcake' ),


### PR DESCRIPTION
Because values on the shortcode model are only set on updating a field,
the behaviour for select box fields is somewhat confusing - it may look
like you're selecting the first item in the select list, but if you
haven't actually changed the field UI yet, no value will actually be
sent for that field.

This avoids that issue by setting default values for all the select
fields used in here, so that these fields will always be set when using
the shortcode UI.