### PR TITLE
Convert [img] shortcodes back to tags/captions

### DIFF
--- a/inc/class-img-shortcode-data-migration.php
+++ b/inc/class-img-shortcode-data-migration.php
@@ -7,8 +7,8 @@
 
 class Img_Shortcode_Data_Migration {
 
-	private static function img_shortcode_regex() {
-		$img_shortcode_regex =
+	private static function img_tag_regex() {
+		$img_tag_regex =
 			'(?:<a[^>]+' .
 					'href="(?P<href>[^"]*)"' .
 					'[^>]*>)?' .
@@ -25,9 +25,8 @@ class Img_Shortcode_Data_Migration {
 					'[^>]*>' .
 			'(?:<\/a>)?';
 
-		return $img_shortcode_regex;
+		return $img_tag_regex;
 	}
-
 
 	private static function caption_shortcode_regex() {
 		$caption_shortcode_regex =
@@ -37,6 +36,11 @@ class Img_Shortcode_Data_Migration {
 				'(?: (?P<caption>[^\]]*))' .
 			'\[\[?\/caption\]\]?';
 		return $caption_shortcode_regex;
+	}
+
+	private static function img_shortcode_regex() {
+		$img_shortcode_regex = '\[img ' .  '[^\]]*]';
+		return $img_shortcode_regex;
 	}
 
 	public static function find_img_tags_for_replacement_on_post( $post ) {
@@ -57,10 +61,10 @@ class Img_Shortcode_Data_Migration {
 
 		$replacements = array();
 
-		$img_shortcode_regex = self::img_shortcode_regex();
+		$img_tag_regex = self::img_tag_regex();
 
 		preg_match_all(
-			"/$img_shortcode_regex/s",
+			"/$img_tag_regex/s",
 			$post_content,
 			$matches,
 			PREG_SET_ORDER
@@ -182,6 +186,79 @@ class Img_Shortcode_Data_Migration {
 		return $shortcode;
 	}
 
+
+	/**
+	 * Get all [img] shortcodes in a string for replacement.
+	 *
+	 * Used in converting data added by this plugin back to the default format
+	 * of <img> tags and [caption] shortcodes.
+	 *
+	 */
+	public static function find_img_shortcodes_for_replacement( $post_content ) {
+
+		$replacements = array();
+
+		$img_shortcode_regex = self::img_shortcode_regex();
+
+		preg_match_all(
+			"/$img_shortcode_regex/s",
+			$post_content,
+			$matches,
+			PREG_SET_ORDER
+		);
+
+		if ( 0 === count( $matches ) ) {
+			return array();
+		}
+
+		foreach ( $matches as $matched_pattern ) {
+			$replacements[ $matched_pattern[0] ] = self::convert_img_shortcode_to_tag(
+				$matched_pattern[0]
+			);
+		}
+
+		return $replacements;
+
+	}
+
+
+	/**
+	 * Convert an [img] shortcode as inserted by this plugin to the WP default
+	 * representation.
+	 *
+	 * @param string `[img]` shortcode element
+	 * @return string A `[caption]` shortcode element, or an <img> tag
+	 */
+	public static function convert_img_shortcode_to_tag( $img_shortcode ) {
+		$atts = shortcode_parse_atts( $img_shortcode );
+
+		$caption = isset( $atts['caption'] ) ? $atts['caption'] : '';
+		unset( $atts['caption'] );
+
+		$width = isset( $atts['width'] ) ? $atts['width'] : '';
+
+		$content = Img_Shortcode::callback( $atts );
+
+		if ( ! isset( $width ) && isset( $atts['attachment'] ) ) {
+			$attachment = wp_get_attachment_image_src(
+				(int) $attr['attachment'], $attr['size']
+			);
+			$width = intval( $attachment[1] );
+		}
+
+		if ( $caption ) {
+			$content =
+				'[caption ' .
+					'width ="' . $width . '" ' .
+					'caption="' . $caption . '" ' .
+					'align="' . $atts['align'] . '" ' .
+					']' .
+				$content .
+				'[/caption]';
+		}
+
+		return $content;
+	}
 
 	/**
 	 * Get a post from a Post ID or post object.


### PR DESCRIPTION
See #20.

Introduces a method to the Img_Shortcode_Data_Migration class to convert
all the shortcodes added by this plugin back to the default WP format,
and a WP-CLI command to access it.

Still needs tests. Also there are some edge cases which break it (mostly dealing with caption widths), which should be identified and fixed in tests.
