### PR TITLE
Set alt and caption fields on selecting attachment

### DIFF
--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -17,14 +17,16 @@ var ImageShortcake = {
 			var attachment = sui.views.editAttributeFieldAttachment.getFromCache( changed.value );
 
 			if ( attachment ) {
-				var altField = sui.views.editAttributeField.getField( collection, 'alt' );
-				var captionField = sui.views.editAttributeField.getField( collection, 'caption' );
 
-				if ( ! altField.model.get('value') && attachment.alt ) {
+				var attrView = sui.views.editAttributeField,
+					altField = attrView.getField( collection, 'alt' ),
+					captionField = attrView.getField( collection, 'caption' );
+
+				if ( ! altField.getValue() && attachment.alt ) {
 					altField.$el.find('[name="alt"]').val( attachment.alt );
 				}
 
-				if ( ! captionField.model.get('value') && attachment.caption ) {
+				if ( ! captionField.getValue() && attachment.caption ) {
 					captionField.$el.find('[name="caption"]').val( attachment.caption );
 				}
 			}

--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -3,6 +3,32 @@ var ImageShortcake = {
 
 	listeners: {
 		/**
+		 * Callback for the "attachment" attribute field.
+		 *
+		 * When selecting an attachment for an [img], try to populate image
+		 * shortcode attribute fields (alt, caption, description,etc.) from
+		 * the attachment data.
+		 */
+		attachment: function( changed, collection, shortcode ) {
+			if ( typeof changed.value === 'undefined' || typeof window.sui.data.idCache[ changed.value ] === 'undefined' ) {
+				return;
+			}
+			var attachment = window.sui.data.idCache[ changed.value ];
+
+			var altField = _.find( collection, function( viewModel ) { return 'alt' === viewModel.model.get('attr'); } );
+			var captionField = _.find( collection, function( viewModel ) { return 'caption' === viewModel.model.get('attr'); } );
+
+			if ( ! altField.model.get('value') && attachment.alt ) {
+				altField.$el.find('[name="alt"]').val( attachment.alt );
+			}
+
+			if ( ! captionField.model.get('value') && attachment.caption ) {
+				captionField.$el.find('[name="caption"]').val( attachment.caption );
+			}
+
+		},
+
+		/**
 		 * Callback for the "linkto" attribute field.
 		 *
 		 * Display the "Custom Link" field if and only if the "linkto" field is "custom"
@@ -27,6 +53,7 @@ var ImageShortcake = {
  */
 if ( typeof wp.shortcake !== 'undefined' && typeof wp.shortcake.hooks !== 'undefined' ) {
 
-	wp.shortcake.hooks.addAction( 'img.linkto', ImageShortcake.listeners.linkto );
+	wp.shortcake.hooks.addAction( 'img.attachment', ImageShortcake.listeners.attachment );
+	wp.shortcake.hooks.addAction( 'img.linkto',     ImageShortcake.listeners.linkto     );
 
 }

--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -13,11 +13,12 @@ var ImageShortcake = {
 			if ( typeof changed.value === 'undefined' ) {
 				return;
 			}
+
 			var attachment = sui.views.editAttributeFieldAttachment.getFromCache( changed.value );
 
 			if ( attachment ) {
-				var altField = _.find( collection, function( viewModel ) { return 'alt' === viewModel.model.get('attr'); } );
-				var captionField = _.find( collection, function( viewModel ) { return 'caption' === viewModel.model.get('attr'); } );
+				var altField = sui.views.editAttributeField.getField( collection, 'alt' );
+				var captionField = sui.views.editAttributeField.getField( collection, 'caption' );
 
 				if ( ! altField.model.get('value') && attachment.alt ) {
 					altField.$el.find('[name="alt"]').val( attachment.alt );
@@ -35,7 +36,7 @@ var ImageShortcake = {
 		 * Display the "Custom Link" field if and only if the "linkto" field is "custom"
 		 */
 		linkto: function( changed, collection, shortcode ) {
-			var customLinkField = _.find( collection, function( viewModel ) { return 'url' === viewModel.model.get('attr'); } );
+			var customLinkField = sui.views.editAttributeField.getField( collection, 'url' );
 
 			if ( changed.value === 'custom' ) {
 				customLinkField.$el.show()

--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -10,22 +10,23 @@ var ImageShortcake = {
 		 * the attachment data.
 		 */
 		attachment: function( changed, collection, shortcode ) {
-			if ( typeof changed.value === 'undefined' || typeof window.sui.data.idCache[ changed.value ] === 'undefined' ) {
+			if ( typeof changed.value === 'undefined' ) {
 				return;
 			}
-			var attachment = window.sui.data.idCache[ changed.value ];
+			var attachment = sui.views.editAttributeFieldAttachment.getFromCache( changed.value );
 
-			var altField = _.find( collection, function( viewModel ) { return 'alt' === viewModel.model.get('attr'); } );
-			var captionField = _.find( collection, function( viewModel ) { return 'caption' === viewModel.model.get('attr'); } );
+			if ( attachment ) {
+				var altField = _.find( collection, function( viewModel ) { return 'alt' === viewModel.model.get('attr'); } );
+				var captionField = _.find( collection, function( viewModel ) { return 'caption' === viewModel.model.get('attr'); } );
 
-			if ( ! altField.model.get('value') && attachment.alt ) {
-				altField.$el.find('[name="alt"]').val( attachment.alt );
+				if ( ! altField.model.get('value') && attachment.alt ) {
+					altField.$el.find('[name="alt"]').val( attachment.alt );
+				}
+
+				if ( ! captionField.model.get('value') && attachment.caption ) {
+					captionField.$el.find('[name="caption"]').val( attachment.caption );
+				}
 			}
-
-			if ( ! captionField.model.get('value') && attachment.caption ) {
-				captionField.$el.find('[name="caption"]').val( attachment.caption );
-			}
-
 		},
 
 		/**


### PR DESCRIPTION
When selecting a new attachment for an [img] shortcode, the alt and caption attributes should be inherited from the attachment post.

See #12.

Depends on https://github.com/fusioneng/Shortcake/pull/358.

