### PR TITLE
Move caption html/quote warning here

### DIFF
--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -1,38 +1,41 @@
-var ImageShortcakeMedia = {};
-(function( $ ){
-	 /*
-	  * Callback to manipulate the attachment details and two column template, onReady. 
-	  */
-	 ImageShortcakeMedia.wpMediaViewAttachmentDetails = function() {
-		var attachmentDetailsTemplate = $("#tmpl-attachment-details"),
-		 	attachmentDetailsHtml = attachmentDetailsTemplate.html(),
-			attachmentDetailsTwoColumnTemplate = $("#tmpl-attachment-details-two-column"),
-			attachmentDetailsTwoColumnHtml = attachmentDetailsTwoColumnTemplate.html(),
+/*
+ * Callback to manipulate the attachment details and two column template, onReady. 
+ */
+function updateStringsForImageShortcake() {
+	var attachmentDetailsTemplate = jQuery("#tmpl-attachment-details");
 
-			customCaption = '<# if( "image" === data.type ) { #>' +
-							'<span class="name">Caption</span>' +
-							'<# } #>' +
-							'<textarea {{ maybeReadOnly }}>{{ data.caption }}</textarea>' +
-							'<div class="image-shortcake-warning">Quote marks and HTML tags are not allowed in captions.</div>' +
-							'<style scoped>.image-shortcake-warning { display: block;float: right;width: 65%;margin-bottom: 5px;font-style: italic; }@media (max-width: 900px) { .image-shortcake-warning { width: 100%;} } </style>';
+	if ( ! attachmentDetailsTemplate ) {
+		return;
+	}
 
-		/** 
-		 * Use string methods hack.
-		 */
-		var newHtml = attachmentDetailsHtml.replace(/(<label class="setting" data-setting="caption">)[\w\W]*?(<\/label>)/,"$1 " + customCaption + " $2");
-		newHtml = newHtml.replace(/(<label class="setting" data-setting="description">[\w\W]*?<\/label>)/,"<# if( 'image' === data.type ) { #>$1<# } #>");
-		attachmentDetailsTemplate.text( newHtml );
-		
-		newHtml = attachmentDetailsTwoColumnHtml.replace(/(<label class="setting" data-setting="caption">)[\w\W]*?(<\/label>)/,"$1 " + customCaption + " $2");
-		newHtml = newHtml.replace(/(<label class="setting" data-setting="description">[\w\W]*?<\/label>)/,"<# if( 'image' === data.type ) { #>$1<# } #>");
-		attachmentDetailsTwoColumnTemplate.text( newHtml );
-	};
+	var attachmentDetailsHtml = attachmentDetailsTemplate.html(),
+		attachmentDetailsTwoColumnTemplate = jQuery("#tmpl-attachment-details-two-column"),
+		attachmentDetailsTwoColumnHtml = attachmentDetailsTwoColumnTemplate.html(),
 
-	$(document).ready(function(){
-		ImageShortcakeMedia.wpMediaViewAttachmentDetails();
-	});
+		customCaption = '<# if( "image" === data.type ) { #>' +
+						'<span class="name">' +
+						image_shortcake_strings.caption +
+						'</span>' +
+						'<# } #>' +
+						'<textarea {{ maybeReadOnly }}>{{ data.caption }}</textarea>' +
+						'<div class="image-shortcake-warning">Quote marks and HTML tags are not allowed in captions.</div>' +
+						'<style scoped>.image-shortcake-warning { display: block;float: right;width: 65%;margin-bottom: 5px;font-style: italic; }@media (max-width: 900px) { .image-shortcake-warning { width: 100%;} } </style>';
 
-}( jQuery ) );
+	/** 
+	 * Use string methods hack.
+	 */
+	var newHtml = attachmentDetailsHtml.replace(/(<label class="setting" data-setting="caption">)[\w\W]*?(<\/label>)/,"$1 " + customCaption + " $2");
+	newHtml = newHtml.replace(/(<label class="setting" data-setting="description">[\w\W]*?<\/label>)/,"<# if( 'image' === data.type ) { #>$1<# } #>");
+	attachmentDetailsTemplate.text( newHtml );
+	
+	newHtml = attachmentDetailsTwoColumnHtml.replace(/(<label class="setting" data-setting="caption">)[\w\W]*?(<\/label>)/,"$1 " + customCaption + " $2");
+	newHtml = newHtml.replace(/(<label class="setting" data-setting="description">[\w\W]*?<\/label>)/,"<# if( 'image' === data.type ) { #>$1<# } #>");
+	attachmentDetailsTwoColumnTemplate.text( newHtml );
+};
+
+jQuery(document).ready(function(){
+	updateStringsForImageShortcake();
+});
 
 var ImageShortcake = {
 

--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -1,3 +1,38 @@
+var ImageShortcakeMedia = {};
+(function( $ ){
+	 /*
+	  * Callback to manipulate the attachment details and two column template, onReady. 
+	  */
+	 ImageShortcakeMedia.wpMediaViewAttachmentDetails = function() {
+		var attachmentDetailsTemplate = $("#tmpl-attachment-details"),
+		 	attachmentDetailsHtml = attachmentDetailsTemplate.html(),
+			attachmentDetailsTwoColumnTemplate = $("#tmpl-attachment-details-two-column"),
+			attachmentDetailsTwoColumnHtml = attachmentDetailsTwoColumnTemplate.html(),
+
+			customCaption = '<# if( "image" === data.type ) { #>' +
+							'<span class="name">Caption</span>' +
+							'<# } #>' +
+							'<textarea {{ maybeReadOnly }}>{{ data.caption }}</textarea>' +
+							'<div class="image-shortcake-warning">Quote marks and HTML tags are not allowed in captions.</div>' +
+							'<style scoped>.image-shortcake-warning { display: block;float: right;width: 65%;margin-bottom: 5px;font-style: italic; }@media (max-width: 900px) { .image-shortcake-warning { width: 100%;} } </style>';
+
+		/** 
+		 * Use string methods hack.
+		 */
+		var newHtml = attachmentDetailsHtml.replace(/(<label class="setting" data-setting="caption">)[\w\W]*?(<\/label>)/,"$1 " + customCaption + " $2");
+		newHtml = newHtml.replace(/(<label class="setting" data-setting="description">[\w\W]*?<\/label>)/,"<# if( 'image' === data.type ) { #>$1<# } #>");
+		attachmentDetailsTemplate.text( newHtml );
+		
+		newHtml = attachmentDetailsTwoColumnHtml.replace(/(<label class="setting" data-setting="caption">)[\w\W]*?(<\/label>)/,"$1 " + customCaption + " $2");
+		newHtml = newHtml.replace(/(<label class="setting" data-setting="description">[\w\W]*?<\/label>)/,"<# if( 'image' === data.type ) { #>$1<# } #>");
+		attachmentDetailsTwoColumnTemplate.text( newHtml );
+	};
+
+	$(document).ready(function(){
+		ImageShortcakeMedia.wpMediaViewAttachmentDetails();
+	});
+
+}( jQuery ) );
 
 var ImageShortcake = {
 

--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -18,7 +18,9 @@ function updateStringsForImageShortcake() {
 						'</span>' +
 						'<# } #>' +
 						'<textarea {{ maybeReadOnly }}>{{ data.caption }}</textarea>' +
-						'<div class="image-shortcake-warning">Quote marks and HTML tags are not allowed in captions.</div>' +
+						'<div class="image-shortcake-warning">' +
+						image_shortcake_strings.warning +
+						'.</div>' +
 						'<style scoped>.image-shortcake-warning { display: block;float: right;width: 65%;margin-bottom: 5px;font-style: italic; }@media (max-width: 900px) { .image-shortcake-warning { width: 100%;} } </style>';
 
 	/** 

--- a/image-shortcake.php
+++ b/image-shortcake.php
@@ -98,11 +98,16 @@ class Image_Shortcake {
 
 
 	/**
-	 * Enqueues the attribute event handler functions on edit page
+	 * Enqueues the attribute event handler functions on edit page 
+	 * Adds some localized text
 	 *
 	 */
 	public function action_enqueue_shortcode_ui() {
 		wp_enqueue_script( 'image-shortcake-admin', plugin_dir_url( __FILE__ ) . 'assets/js/image-shortcake-admin.js', false, IMAGE_SHORTCAKE_VERSION );
+		$translation_array = array(
+			'caption' => __( 'Caption', 'image-shortcake' ),
+		);
+		wp_localize_script( 'image-shortcake-admin', 'image_shortcake_strings', $translation_array );
 	}
 
 

--- a/image-shortcake.php
+++ b/image-shortcake.php
@@ -98,7 +98,7 @@ class Image_Shortcake {
 
 
 	/**
-	 * Enqueues the attribute event handler functions on edit page 
+	 * Enqueues the attribute event handler functions on edit page
 	 * Adds some localized text
 	 *
 	 */

--- a/image-shortcake.php
+++ b/image-shortcake.php
@@ -106,6 +106,7 @@ class Image_Shortcake {
 		wp_enqueue_script( 'image-shortcake-admin', plugin_dir_url( __FILE__ ) . 'assets/js/image-shortcake-admin.js', false, IMAGE_SHORTCAKE_VERSION );
 		$translation_array = array(
 			'caption' => __( 'Caption', 'image-shortcake' ),
+			'warning' => __( 'Quote marks and HTML tags are not allowed in captions', 'image-shortcake' ),
 		);
 		wp_localize_script( 'image-shortcake-admin', 'image_shortcake_strings', $translation_array );
 	}


### PR DESCRIPTION
See https://github.com/fusioneng/image-shortcake/issues/51

<img width="240" alt="screen shot 2015-08-10 at 10 21 37 am" src="https://cloud.githubusercontent.com/assets/1636964/9173779/6235e710-3f4a-11e5-930c-d7943185030b.png">

Style inline to prevent another HTTP call on the admin-side (no stylesheet currently).