### PR TITLE
Fix call to removed `getFromCache` function in Shortcake

### DIFF
--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -54,7 +54,7 @@ var ImageShortcake = {
 				return;
 			}
 
-			var attachment = sui.views.editAttributeFieldAttachment.getFromCache( changed.value );
+			var attachment = wp.media.attachment( changed.value ).attributes;
 
 			if ( attachment ) {
 
@@ -97,7 +97,7 @@ var ImageShortcake = {
  */
 if ( typeof wp.shortcake !== 'undefined' && typeof wp.shortcake.hooks !== 'undefined' ) {
 
-	wp.shortcake.hooks.addAction( 'img.attachment', ImageShortcake.listeners.attachment );
+	//wp.shortcake.hooks.addAction( 'img.attachment', ImageShortcake.listeners.attachment );
 	wp.shortcake.hooks.addAction( 'img.linkto',     ImageShortcake.listeners.linkto     );
 
 }

--- a/assets/js/image-shortcake-admin.js
+++ b/assets/js/image-shortcake-admin.js
@@ -97,7 +97,7 @@ var ImageShortcake = {
  */
 if ( typeof wp.shortcake !== 'undefined' && typeof wp.shortcake.hooks !== 'undefined' ) {
 
-	//wp.shortcake.hooks.addAction( 'img.attachment', ImageShortcake.listeners.attachment );
+	wp.shortcake.hooks.addAction( 'img.attachment', ImageShortcake.listeners.attachment );
 	wp.shortcake.hooks.addAction( 'img.linkto',     ImageShortcake.listeners.linkto     );
 
 }


### PR DESCRIPTION
d'oh. I had forgotten that this bug hadn't been fixed here yet. Sorry to
everyone who had to patch it locally.

Fixes #75.